### PR TITLE
feat(auth): hacer login page responsive para móvil

### DIFF
--- a/src/app/auth/pages/login-page/login-page.component.html
+++ b/src/app/auth/pages/login-page/login-page.component.html
@@ -8,12 +8,12 @@
 <div class="absolute inset-0 bg-background/75"></div>
 
 <!-- Login card -->
-<div class="relative z-10 w-full max-w-md p-8 mx-4 bg-surface/85 backdrop-blur-sm rounded-2xl shadow-2xl border border-border-subtle/50 transition-all duration-500">
+<div class="relative z-10 w-full max-w-md p-5 sm:p-8 mx-4 bg-surface/85 backdrop-blur-sm rounded-2xl shadow-2xl border border-border-subtle/50 transition-all duration-500">
 
   <!-- Logo & título -->
-  <div class="text-center mb-8">
+  <div class="text-center mb-5 sm:mb-8">
     <div class="flex items-center justify-center gap-2 mb-3 text-brand">
-      <svg xmlns="http://www.w3.org/2000/svg" width="40" height="40" viewBox="0 0 24 24">
+      <svg xmlns="http://www.w3.org/2000/svg" class="w-8 h-8 sm:w-10 sm:h-10" viewBox="0 0 24 24">
         <path fill="currentColor" d="m8.1 13.34l2.83-2.83L3.91 3.5a4.01 4.01 0 0 0 0 5.66zm6.78-1.81c1.53.71 3.68.21 5.27-1.38c1.91-1.91 2.28-4.65.81-6.12c-1.46-1.46-4.2-1.1-6.12.81c-1.59 1.59-2.09 3.74-1.38 5.27L3.7 19.87l1.41 1.41L12 14.41l6.88 6.88l1.41-1.41L13.41 13z"/>
       </svg>
       <h1 class="text-3xl sm:text-4xl font-bold text-text-primary">El {{ envs.companyName }}</h1>


### PR DESCRIPTION
Ajusta padding del card y margen del header con breakpoints sm para que la pantalla de login no quede comprimida en pantallas pequeñas.