### PR TITLE
feat: mejoras de pagos, responsividad y gestión de clientes

### DIFF
--- a/src/app/orders/components/order-view/order-view.component.ts
+++ b/src/app/orders/components/order-view/order-view.component.ts
@@ -18,6 +18,7 @@ import {
 import { CulqiService } from '@src/app/shared/services/culqi.service';
 import { PaymentsService } from '@src/app/payments/services/payments.service';
 import { ContentPayment } from '@src/app/payments/interfaces/payments.inteface';
+import { OrderService } from '../../services/order.service';
 import { ConfirmModifyModalComponent } from '../confirm-modify-modal/confirm-modify-modal.component';
 import { ConfirmStatusModalComponent } from '../confirm-status-modal/confirm-status-modal.component';
 import { PaymentCheckoutComponent } from '@src/app/payments/components/payment-checkout/payment-checkout.component';
@@ -48,6 +49,7 @@ interface StatusChange {
 export class OrderViewComponent {
   private culqiService    = inject(CulqiService);
   private paymentsService = inject(PaymentsService);
+  private orderService    = inject(OrderService);
   private router          = inject(Router);
 
   selectedTable    = input<Table | null>();
@@ -162,6 +164,10 @@ export class OrderViewComponent {
     this.paymentsService.getPaymentByOrderId(this.activeOrder().id).subscribe(
       (payment) => this.existingPayment.set(payment)
     );
+    // El WebSocket confirmó el pago → cambiar estado del pedido a PAID
+    if (culqiOrder.state === 'paid') {
+      this.orderService.updateOrderStatus(this.activeOrder().id, OrderStatus.PAID).subscribe();
+    }
   }
 
   onPaymentError(error: any) { console.error('Error en el pago:', error); }


### PR DESCRIPTION
## Summary

- **feat(payments)**: el estado del pedido cambia automáticamente a `PAID` al confirmar el pago vía WebSocket (Culqi/Yape), liberando la mesa en tiempo real
- **feat(auth)**: login page responsive para móvil (padding y márgenes adaptativos con breakpoint `sm`)
- **feat(clients)**: nueva página de gestión de clientes con CRUD, modal de formulario y enlace en sidebar
- **refactor/fix**: extracción de `ClientFormInlineComponent`, correcciones en `clientsResource` y referencias a `departament`

## Test plan

- [ ] Crear una orden, procesarla con billetera digital (Yape/Culqi) y verificar que al confirmar el pago el estado cambia a `PAID` y la mesa queda disponible sin acción manual
- [ ] Abrir la página de login desde un dispositivo móvil y verificar que el card se adapta correctamente sin desbordamiento
- [ ] Ingresar a la página de clientes y probar crear, editar y eliminar un cliente

🤖 Generated with [Claude Code](https://claude.com/claude-code)